### PR TITLE
Replace `CLOCK_MONOTONIC` with `CLOCK_BOOTTIME`

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -2,3 +2,10 @@ rootProject.name = 'DataDogTry'
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')
+
+includeBuild('../node_modules/react-native') {
+    dependencySubstitution {
+        substitute(module("com.facebook.react:react-android")).using(project(":packages:react-native:ReactAndroid"))
+        substitute(module("com.facebook.react:react-native")).using(project(":packages:react-native:ReactAndroid"))
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "start": "react-native start",
-    "test": "jest"
+    "test": "jest",
+    "postinstall": "npx patch-package"
   },
   "dependencies": {
     "@react-navigation/native": "^6.1.17",

--- a/patches/react-native+0.74.1.patch
+++ b/patches/react-native+0.74.1.patch
@@ -1,0 +1,76 @@
+diff --git a/node_modules/react-native/ReactCommon/cxxreact/boot_clock.h b/node_modules/react-native/ReactCommon/cxxreact/boot_clock.h
+new file mode 100644
+--- /dev/null	2024-05-28 12:12:50
++++ b/node_modules/react-native/ReactCommon/cxxreact/boot_clock.h
+@@ -0,0 +1,19 @@
++// boot_clock.h
++#ifndef BOOT_CLOCK_H
++#define BOOT_CLOCK_H
++
++#include <chrono>
++#ifdef __linux__
++#include <ctime>
++#endif
++
++// A std::chrono clock based on CLOCK_BOOTTIME.
++class boot_clock {
++ public:
++  typedef std::chrono::nanoseconds duration;
++  typedef std::chrono::time_point<boot_clock, duration> time_point;
++
++  static time_point now();
++};
++
++#endif // BOOT_CLOCK_H
+\ No newline at end of file
+diff --git a/node_modules/react-native/ReactCommon/cxxreact/boot_clock.cpp b/node_modules/react-native/ReactCommon/cxxreact/boot_clock.cpp
+new file mode 100644
+--- /dev/null	2024-05-28 12:12:59
++++ b/node_modules/react-native/ReactCommon/cxxreact/boot_clock.cpp
+@@ -0,0 +1,14 @@
++// boot_clock.cpp
++#include "boot_clock.h"
++
++boot_clock::time_point boot_clock::now() {
++#ifdef __linux__
++  timespec ts;
++  clock_gettime(CLOCK_BOOTTIME, &ts);
++  return boot_clock::time_point(std::chrono::seconds(ts.tv_sec) +
++                                std::chrono::nanoseconds(ts.tv_nsec));
++#else
++  // Darwin and Windows do not support clock_gettime.
++  return boot_clock::time_point();
++#endif  // __linux__
++}
+\ No newline at end of file
+diff --git a/node_modules/react-native/ReactCommon/cxxreact/JSExecutor.cpp b/node_modules/react-native/ReactCommon/cxxreact/JSExecutor.cpp
+--- a/node_modules/react-native/ReactCommon/cxxreact/JSExecutor.cpp
++++ b/node_modules/react-native/ReactCommon/cxxreact/JSExecutor.cpp
+@@ -8,6 +8,7 @@
+ #include "JSExecutor.h"
+ 
+ #include "RAMBundleRegistry.h"
++#include "boot_clock.h"
+ 
+ #include <folly/Conv.h>
+ #include <jsinspector-modern/ReactCdp.h>
+@@ -26,10 +27,8 @@
+ }
+ 
+ double JSExecutor::performanceNow() {
+-  auto time = std::chrono::steady_clock::now();
+-  auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
+-                      time.time_since_epoch())
+-                      .count();
++  auto time = boot_clock::now();
++  auto duration = time.time_since_epoch().count();
+ 
+   constexpr double NANOSECONDS_IN_MILLISECOND = 1000000.0;
+   return duration / NANOSECONDS_IN_MILLISECOND;
+@@ -47,4 +46,4 @@
+       std::move(frontendChannel), sessionState, getDescription());
+ }
+ 
+-} // namespace facebook::react
+\ No newline at end of file
++} // namespace facebook::react


### PR DESCRIPTION
React Native is using [std::chrono::steady_clock](https://github.com/facebook/react-native/blob/ea3a7143b9c8e886a6cf5ffd04386c3b19ef6b4a/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp#L29) as monotonic clock for the `performance.now()` output.

[According to this Google engineer](https://github.com/android/ndk/issues/1101#issuecomment-542303371), `std::chrono::steady_clock` does not count time that the system is suspended, which makes it unreliable for the Datadog use-case. 

In the patch in this PR, I've replaced the React Native`steady_clock` usage with the snippet the Google engineer shared, which is using `CLOCK_BOOTTIME` instead. A clock that's monotonic, but also continues while the system is suspended. Apparently, this is what's being used in Android OS itself as well, and I can confirm it fixes the timing issues we are experiencing using Datadog on Android.